### PR TITLE
Adicionando end-point de categorias junto com as validações

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
 
 	<properties>
 		<java.version>1.8</java.version>
+		<org.mapstruct.version>1.4.0.Final</org.mapstruct.version>
 	</properties>
 
 	<dependencies>
@@ -59,7 +60,15 @@
 			<artifactId>springfox-swagger-ui</artifactId>
 			<version>2.9.2</version>
 		</dependency>
-
+		<dependency>
+			<groupId>org.mapstruct</groupId>
+			<artifactId>mapstruct</artifactId>
+			<version>${org.mapstruct.version}</version>
+		</dependency>
+			<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -67,6 +76,23 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+
+				<configuration>
+					<source>1.8</source> <!-- depending on your project -->
+					<target>1.8</target> <!-- depending on your project -->
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.mapstruct</groupId>
+							<artifactId>mapstruct-processor</artifactId>
+							<version>${org.mapstruct.version}</version>
+						</path>
+						<!-- other annotation processors -->
+					</annotationProcessorPaths>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/src/main/java/com/ludmylla/personal/bill/PersonalBillApplication.java
+++ b/src/main/java/com/ludmylla/personal/bill/PersonalBillApplication.java
@@ -1,13 +1,13 @@
-package com.ludmylla.personal.account.api;
+package com.ludmylla.personal.bill;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-public class PersonalAccountApplication {
+public class PersonalBillApplication {
 
 	public static void main(String[] args) {
-		SpringApplication.run(PersonalAccountApplication.class, args);
+		SpringApplication.run(PersonalBillApplication.class, args);
 	}
 
 }

--- a/src/main/java/com/ludmylla/personal/bill/SwaggerConfig.java
+++ b/src/main/java/com/ludmylla/personal/bill/SwaggerConfig.java
@@ -1,4 +1,4 @@
-package com.ludmylla.personal.account.api;
+package com.ludmylla.personal.bill;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/ludmylla/personal/bill/mapper/CategoryMapper.java
+++ b/src/main/java/com/ludmylla/personal/bill/mapper/CategoryMapper.java
@@ -7,24 +7,19 @@ import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 
 import com.ludmylla.personal.bill.model.Category;
-import com.ludmylla.personal.bill.model.dto.CategoryInsertDto;
-import com.ludmylla.personal.bill.model.dto.CategoryListAllDto;
+import com.ludmylla.personal.bill.model.dto.CategoryInsertAndListAllDto;
 import com.ludmylla.personal.bill.model.dto.CategoryUpdateDto;
 
 @Mapper
 public interface CategoryMapper {
 
 	CategoryMapper INSTANCE = Mappers.getMapper(CategoryMapper.class);
-	
+
 	@Mapping(target = "id", ignore = true)
-	Category toCategoryInsertDto (CategoryInsertDto source);
+	Category toCategoryInsertAndListAllDto(CategoryInsertAndListAllDto source);
+
+	Category toCategoryUpdateDto(CategoryUpdateDto source);
 	
-	Category toCategoryUpdateDto (CategoryUpdateDto source);
-	
-	@Mapping(target= "id", ignore = true)
-	Category toCategoryListAllDto (CategoryListAllDto source);
-	
-	List<CategoryListAllDto> dtoCategoryListAllDto (List<Category> source);
-	
-	
+	List<CategoryInsertAndListAllDto> dtoCategoryInsertAndListAll (List<Category> source);
+
 }

--- a/src/main/java/com/ludmylla/personal/bill/mapper/CategoryMapper.java
+++ b/src/main/java/com/ludmylla/personal/bill/mapper/CategoryMapper.java
@@ -1,0 +1,30 @@
+package com.ludmylla.personal.bill.mapper;
+
+import java.util.List;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+import com.ludmylla.personal.bill.model.Category;
+import com.ludmylla.personal.bill.model.dto.CategoryInsertDto;
+import com.ludmylla.personal.bill.model.dto.CategoryListAllDto;
+import com.ludmylla.personal.bill.model.dto.CategoryUpdateDto;
+
+@Mapper
+public interface CategoryMapper {
+
+	CategoryMapper INSTANCE = Mappers.getMapper(CategoryMapper.class);
+	
+	@Mapping(target = "id", ignore = true)
+	Category toCategoryInsertDto (CategoryInsertDto source);
+	
+	Category toCategoryUpdateDto (CategoryUpdateDto source);
+	
+	@Mapping(target= "id", ignore = true)
+	Category toCategoryListAllDto (CategoryListAllDto source);
+	
+	List<CategoryListAllDto> dtoCategoryListAllDto (List<Category> source);
+	
+	
+}

--- a/src/main/java/com/ludmylla/personal/bill/model/Category.java
+++ b/src/main/java/com/ludmylla/personal/bill/model/Category.java
@@ -1,0 +1,75 @@
+package com.ludmylla.personal.bill.model;
+
+import java.io.Serializable;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+@Entity
+public class Category implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	
+	@NotNull(message = "Category cannot be null.")
+	@NotBlank(message = "Category cannot be blank.")
+	@Size(min = 3, max = 50, message = "Category must have a minimum of 3 letters and a maximum of 50.")
+	@Column(unique = true)
+	private String name;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((id == null) ? 0 : id.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		Category other = (Category) obj;
+		if (id == null) {
+			if (other.id != null)
+				return false;
+		} else if (!id.equals(other.id))
+			return false;
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		return "Category [id=" + id + ", name=" + name + "]";
+	}
+
+}

--- a/src/main/java/com/ludmylla/personal/bill/model/dto/CategoryInsertAndListAllDto.java
+++ b/src/main/java/com/ludmylla/personal/bill/model/dto/CategoryInsertAndListAllDto.java
@@ -1,6 +1,6 @@
 package com.ludmylla.personal.bill.model.dto;
 
-public class CategoryInsertDto {
+public class CategoryInsertAndListAllDto {
 
 	private String name;
 

--- a/src/main/java/com/ludmylla/personal/bill/model/dto/CategoryInsertDto.java
+++ b/src/main/java/com/ludmylla/personal/bill/model/dto/CategoryInsertDto.java
@@ -1,0 +1,15 @@
+package com.ludmylla.personal.bill.model.dto;
+
+public class CategoryInsertDto {
+
+	private String name;
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+}

--- a/src/main/java/com/ludmylla/personal/bill/model/dto/CategoryListAllDto.java
+++ b/src/main/java/com/ludmylla/personal/bill/model/dto/CategoryListAllDto.java
@@ -1,0 +1,15 @@
+package com.ludmylla.personal.bill.model.dto;
+
+public class CategoryListAllDto {
+
+	private String name;
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+}

--- a/src/main/java/com/ludmylla/personal/bill/model/dto/CategoryUpdateDto.java
+++ b/src/main/java/com/ludmylla/personal/bill/model/dto/CategoryUpdateDto.java
@@ -1,0 +1,24 @@
+package com.ludmylla.personal.bill.model.dto;
+
+public class CategoryUpdateDto {
+
+	private Long id;
+	private String name;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+}

--- a/src/main/java/com/ludmylla/personal/bill/repository/CategoryRepository.java
+++ b/src/main/java/com/ludmylla/personal/bill/repository/CategoryRepository.java
@@ -1,0 +1,13 @@
+package com.ludmylla.personal.bill.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ludmylla.personal.bill.model.Category;
+
+@Transactional
+@Repository
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+}

--- a/src/main/java/com/ludmylla/personal/bill/resource/CategoryResource.java
+++ b/src/main/java/com/ludmylla/personal/bill/resource/CategoryResource.java
@@ -17,8 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.ludmylla.personal.bill.mapper.CategoryMapper;
 import com.ludmylla.personal.bill.model.Category;
-import com.ludmylla.personal.bill.model.dto.CategoryInsertDto;
-import com.ludmylla.personal.bill.model.dto.CategoryListAllDto;
+import com.ludmylla.personal.bill.model.dto.CategoryInsertAndListAllDto;
 import com.ludmylla.personal.bill.model.dto.CategoryUpdateDto;
 import com.ludmylla.personal.bill.service.CategoryService;
 
@@ -29,9 +28,9 @@ public class CategoryResource {
 	private CategoryService categoryService;
 	
 	@PostMapping(path = "/categories")
-	public ResponseEntity<String> createCategory(@Valid @RequestBody CategoryInsertDto categoryInsertDto){
+	public ResponseEntity<String> createCategory(@Valid @RequestBody CategoryInsertAndListAllDto categoryInsertAndListAllDto){
 		try {
-			Category category = CategoryMapper.INSTANCE.toCategoryInsertDto(categoryInsertDto);
+			Category category = CategoryMapper.INSTANCE.toCategoryInsertAndListAllDto(categoryInsertAndListAllDto);
 			
 			categoryService.save(category);
 			
@@ -47,16 +46,16 @@ public class CategoryResource {
 	}
 	
 	@GetMapping(path = "/categories")
-	public ResponseEntity<List<CategoryListAllDto>> listAll(){
+	public ResponseEntity<List<CategoryInsertAndListAllDto>> listAll(){
 		try {
 			List<Category> categories = categoryService.listAll();
 			
-			List<CategoryListAllDto> categoryListAllDto = CategoryMapper.INSTANCE
-					.dtoCategoryListAllDto(categories);
+			List<CategoryInsertAndListAllDto> categoryInsertAndListAllDto = CategoryMapper.INSTANCE
+					.dtoCategoryInsertAndListAll(categories);
 			
-			return new ResponseEntity<List<CategoryListAllDto>>(categoryListAllDto,HttpStatus.OK);
+			return new ResponseEntity<List<CategoryInsertAndListAllDto>>(categoryInsertAndListAllDto,HttpStatus.OK);
 		}catch (Exception e) {
-			return new ResponseEntity<List<CategoryListAllDto>>(HttpStatus.BAD_REQUEST);
+			return new ResponseEntity<List<CategoryInsertAndListAllDto>>(HttpStatus.BAD_REQUEST);
 		}
 	}
 	

--- a/src/main/java/com/ludmylla/personal/bill/resource/CategoryResource.java
+++ b/src/main/java/com/ludmylla/personal/bill/resource/CategoryResource.java
@@ -1,0 +1,89 @@
+package com.ludmylla.personal.bill.resource;
+
+import java.util.List;
+
+import javax.validation.Valid;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ludmylla.personal.bill.mapper.CategoryMapper;
+import com.ludmylla.personal.bill.model.Category;
+import com.ludmylla.personal.bill.model.dto.CategoryInsertDto;
+import com.ludmylla.personal.bill.model.dto.CategoryListAllDto;
+import com.ludmylla.personal.bill.model.dto.CategoryUpdateDto;
+import com.ludmylla.personal.bill.service.CategoryService;
+
+@RestController
+public class CategoryResource {
+	
+	@Autowired
+	private CategoryService categoryService;
+	
+	@PostMapping(path = "/categories")
+	public ResponseEntity<String> createCategory(@Valid @RequestBody CategoryInsertDto categoryInsertDto){
+		try {
+			Category category = CategoryMapper.INSTANCE.toCategoryInsertDto(categoryInsertDto);
+			
+			categoryService.save(category);
+			
+			return ResponseEntity.status(HttpStatus.CREATED).body(
+					" Category successfully registered! ");
+			
+		}catch (DataIntegrityViolationException ex) {
+			return ResponseEntity.status(HttpStatus.CONFLICT).body(" Category failure already exists: " + ex.getMessage());
+			
+		}catch (Exception e) {
+			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(" Failed to create category: " + e.getMessage());
+		}
+	}
+	
+	@GetMapping(path = "/categories")
+	public ResponseEntity<List<CategoryListAllDto>> listAll(){
+		try {
+			List<Category> categories = categoryService.listAll();
+			
+			List<CategoryListAllDto> categoryListAllDto = CategoryMapper.INSTANCE
+					.dtoCategoryListAllDto(categories);
+			
+			return new ResponseEntity<List<CategoryListAllDto>>(categoryListAllDto,HttpStatus.OK);
+		}catch (Exception e) {
+			return new ResponseEntity<List<CategoryListAllDto>>(HttpStatus.BAD_REQUEST);
+		}
+	}
+	
+	@PutMapping(path = "/categories")
+	public ResponseEntity<String> updateCategory(@Valid @RequestBody CategoryUpdateDto categoryUpdateDto){
+		try {
+			Category category = CategoryMapper.INSTANCE.toCategoryUpdateDto(categoryUpdateDto);
+			
+			categoryService.update(category);
+			return ResponseEntity.status(HttpStatus.OK).body(" Category update successfully: ");
+		
+		}catch (DataIntegrityViolationException ex) {
+			return ResponseEntity.status(HttpStatus.CONFLICT).body(" Category failure already exists: " + ex.getMessage());
+			
+		}catch (Exception e) {
+			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(" Failed to update: " + e.getMessage());
+		}
+	}
+	
+	@DeleteMapping(path = "/categories")
+	public ResponseEntity<String> deleteCategory(Long id){
+		try {
+			categoryService.delete(id);
+			return ResponseEntity.status(HttpStatus.OK).body(" Category delete successfully! ");
+		} catch (Exception e) {
+			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(" Failed to delete: " + e.getMessage());
+		}
+	}
+	
+}

--- a/src/main/java/com/ludmylla/personal/bill/service/CategoryService.java
+++ b/src/main/java/com/ludmylla/personal/bill/service/CategoryService.java
@@ -1,0 +1,16 @@
+package com.ludmylla.personal.bill.service;
+
+import java.util.List;
+
+import com.ludmylla.personal.bill.model.Category;
+
+public interface CategoryService {
+
+	Long save(Category category);
+	
+	List<Category> listAll();
+	
+	Long update(Category category);
+	
+	void delete(Long id);
+}

--- a/src/main/java/com/ludmylla/personal/bill/service/CategoryServiceImpl.java
+++ b/src/main/java/com/ludmylla/personal/bill/service/CategoryServiceImpl.java
@@ -1,0 +1,101 @@
+package com.ludmylla.personal.bill.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ludmylla.personal.bill.model.Category;
+import com.ludmylla.personal.bill.repository.CategoryRepository;
+import com.ludmylla.personal.bill.useful.Useful;
+
+
+
+
+@Service
+public class CategoryServiceImpl implements CategoryService {
+	
+	@Autowired
+	private CategoryRepository categoryRepository;
+	
+	@Transactional
+	@Override
+	public Long save(Category category) {
+		validations(category);
+		Category categoryCreate = categoryRepository.save(category);
+		return categoryCreate.getId();
+	}
+	
+	@Transactional
+	@Override
+	public List<Category> listAll() {
+		List<Category> categories = new ArrayList<>();
+		List<Category> list = categoryRepository.findAll();
+		list.forEach(categories::add);
+		return list;
+	}
+	
+	@Modifying
+	@Transactional
+	@Override
+	public Long update(Category category) {
+		validIfCategoryExits(category.getId());
+		validations(category);
+		Category categoryUpdate = categoryRepository.save(category);
+		return categoryUpdate.getId();
+	}
+	
+	@Transactional
+	@Override
+	public void delete(Long id) {
+		validIfCategoryExits(id);
+		Optional<Category> category = categoryRepository.findById(id);
+		Category categories = category.get();
+		categoryRepository.delete(categories);
+	}
+	
+	private void validations(Category category) {
+		validIfCategoryNameIsNull(category);
+		validIfCategoryNameIsBlank(category);
+		validTheQuantityOfLettersInCategory(category);
+		validIfTheNameHasNumbersOrSpecialCharacters(category);
+	}
+	
+	private void validIfCategoryNameIsNull(Category category) {
+		boolean isNameNull = category.getName() ==  null;
+		if(isNameNull) {
+			throw new IllegalArgumentException("Category name cannot be null!");
+		}
+	}
+	
+	private void validIfCategoryNameIsBlank(Category category) {
+		boolean isNameBlank = category.getName().isBlank();
+		if(isNameBlank) {
+			throw new IllegalArgumentException("The category name cannot be empty!");
+		}
+	}
+	
+	private void validTheQuantityOfLettersInCategory (Category category) {
+		String isNameMinAndMax = category.getName();
+		if(isNameMinAndMax.length() < 3 || isNameMinAndMax.length() > 50) {
+			throw new IllegalArgumentException("Category must have a minimum of 3 letters and a maximum of 50!");
+		}
+	}
+	
+	private void validIfCategoryExits(Long id) {
+		Optional<Category> category = categoryRepository.findById(id);
+		boolean isCategoryExists = category.isEmpty();
+		if(isCategoryExists) {
+			throw new IllegalArgumentException("Category does not exist!");
+		}
+	}
+	
+	private void validIfTheNameHasNumbersOrSpecialCharacters(Category category) {
+		String hasNumbersOrSpecialCharactersInName = category.getName();
+		Useful.validIfItHasNumbersOrSpecialCharacters(hasNumbersOrSpecialCharactersInName);
+	}	
+}

--- a/src/main/java/com/ludmylla/personal/bill/service/CategoryServiceImpl.java
+++ b/src/main/java/com/ludmylla/personal/bill/service/CategoryServiceImpl.java
@@ -1,6 +1,5 @@
 package com.ludmylla.personal.bill.service;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -12,9 +11,6 @@ import org.springframework.transaction.annotation.Transactional;
 import com.ludmylla.personal.bill.model.Category;
 import com.ludmylla.personal.bill.repository.CategoryRepository;
 import com.ludmylla.personal.bill.useful.Useful;
-
-
-
 
 @Service
 public class CategoryServiceImpl implements CategoryService {
@@ -33,9 +29,7 @@ public class CategoryServiceImpl implements CategoryService {
 	@Transactional
 	@Override
 	public List<Category> listAll() {
-		List<Category> categories = new ArrayList<>();
 		List<Category> list = categoryRepository.findAll();
-		list.forEach(categories::add);
 		return list;
 	}
 	

--- a/src/main/java/com/ludmylla/personal/bill/useful/Useful.java
+++ b/src/main/java/com/ludmylla/personal/bill/useful/Useful.java
@@ -1,0 +1,11 @@
+package com.ludmylla.personal.bill.useful;
+
+public class Useful {
+
+	public static String validIfItHasNumbersOrSpecialCharacters(String compare) {
+		if (!compare.matches("[A-Za-záàâãéèêíïóôõöúçñÁÀÂÃÉÈÍÏÓÔÕÖÚÇÑ ]+$")) {
+			throw new IllegalArgumentException("Cannot contain numbers or special characters!");
+		}
+		return compare;
+	}
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,4 +3,4 @@ spring.datasource.username=root
 spring.datasource.password=admin
 spring.datasource.driver-class-name=com.mysql.jdbc.Driver
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL5Dialect
-spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.hibernate.ddl-auto=update


### PR DESCRIPTION
Foi adicionado os end-point de categoria listar, atualizar, cadastrar e excluir junto também com as validações: verifica se a categoria é em branco, se é nula, a quantidade de caracteres máxima e mínima e também a validação que permite apenas letras ao cadastrar ou atualizar uma categoria. Foi usado uma classe útil para reaproveitar a validação de apenas letras. 